### PR TITLE
FIX: Dep with byName could be from children

### DIFF
--- a/lib/xccache/spm/desc/base.rb
+++ b/lib/xccache/spm/desc/base.rb
@@ -20,8 +20,12 @@ module XCCache
           to_s
         end
 
+        def display_name
+          name
+        end
+
         def to_s
-          "<#{self.class} name=#{name}>"
+          "<#{self.class} name=#{display_name}>"
         end
 
         def pkg_name

--- a/lib/xccache/spm/desc/dep.rb
+++ b/lib/xccache/spm/desc/dep.rb
@@ -4,6 +4,10 @@ module XCCache
   module SPM
     class Package
       class Dependency < BaseObject
+        def display_name
+          slug
+        end
+
         def local?
           raw.key?("fileSystem")
         end
@@ -13,11 +17,22 @@ module XCCache
         end
 
         def slug
-          @slug ||= hash["identity"]
+          @slug ||=
+            if hash.key?("path")
+              File.basename(hash["path"])
+            elsif (location = hash["location"]) && location.key?("remote")
+              File.basename(location["remote"].flat_map(&:values)[0], ".*")
+            else
+              hash["identity"]
+            end
         end
 
         def path
           @path ||= Pathname(hash["path"]).expand_path if local?
+        end
+
+        def pkg_desc
+          @pkg_desc ||= pkg_desc_of(slug)
         end
       end
     end

--- a/lib/xccache/spm/desc/desc.rb
+++ b/lib/xccache/spm/desc/desc.rb
@@ -35,6 +35,10 @@ module XCCache
           @dependencies ||= fetch("dependencies", Dependency)
         end
 
+        def uniform_dependencies
+          dependencies.filter_map(&:pkg_desc)
+        end
+
         def products
           @products ||= fetch("products", Product)
         end


### PR DESCRIPTION
Example: https://github.com/Alamofire/AlamofireImage/blob/master/Package.swift#L37

Target dependency as literal strings could represent one from children