### PR TITLE
FIX: Duplicate symbols in resource_bundle_accessor.m

### DIFF
--- a/lib/xccache/assets/templates/resource_bundle_accessor.m.template
+++ b/lib/xccache/assets/templates/resource_bundle_accessor.m.template
@@ -1,16 +1,16 @@
 #import <Foundation/Foundation.h>
 
-@interface BundleFinder : NSObject
+@interface BundleFinder_<%= module_name %> : NSObject
 @end
 
-@implementation BundleFinder
+@implementation BundleFinder_<%= module_name %>
 @end
 
 NSBundle* <%= module_name %>_SWIFTPM_MODULE_BUNDLE() {
   NSString *bundleName = @"<%= pkg %>_<%= target %>";
   NSArray<NSURL *> *candidates = @[
     NSBundle.mainBundle.resourceURL,
-    [NSBundle bundleForClass:[BundleFinder class]].resourceURL,
+    [NSBundle bundleForClass:[BundleFinder_<%= module_name %> class]].resourceURL,
     NSBundle.mainBundle.bundleURL,
     [NSBundle.mainBundle.bundleURL URLByAppendingPathComponent:@"Frameworks/<%= target %>.framework"]
   ];


### PR DESCRIPTION
Unlike in Swift, classes in ObjC must be unique across modules.