### PR TITLE
FIX: Flat angle-bracket imports in FBSDKLoginKit

### DIFF
--- a/examples/EX/SPMPlayground.swift
+++ b/examples/EX/SPMPlayground.swift
@@ -1,6 +1,7 @@
 import SwiftyBeaver
 import Moya
 import Alamofire
+import CoreUtils_Wrapper
 import DebugKit
 import ResourceKit
 import Swizzler
@@ -8,7 +9,7 @@ import GoogleMaps
 import SDWebImage
 import KingfisherWebP
 import FirebaseCrashlytics
-import CoreUtils_Wrapper
+import FacebookLogin
 
 func swift_playground() {
   print(SwiftyBeaver.self)        // SwiftyBeaver
@@ -22,6 +23,8 @@ func swift_playground() {
   print(SDImageCacheOptions.self) // SDWebImage)
   print(WebPProcessor.self)       // KingfisherWebP
   print(CrashlyticsReport.self)   // FirebaseCrashlytics
+  print(LoginResult.self)         // FacebookLogin
+  print(FBLoginButton.self)       // FBSDKLoginKit
 }
 
 func playground() {

--- a/examples/LocalPackages/core-utils/Package.swift
+++ b/examples/LocalPackages/core-utils/Package.swift
@@ -18,9 +18,7 @@ let package = Package(
     .target(
       name: "Swizzler",
       dependencies: [
-        "CoreUtils-Wrapper",
-        .product(name: "SwiftyBeaver", package: "SwiftyBeaver"),
-        .product(name: "Moya", package: "Moya"),
+        "CoreUtils-Wrapper"
       ]
     ),
     .target(
@@ -30,13 +28,22 @@ let package = Package(
     ),
     .target(
       name: "DebugKit",
-      dependencies: ["CoreUtils-Wrapper"],
-      path: "Sources/DebugKitObjc",
-      resources: [.copy("token.txt")]
+      dependencies: [
+        "CoreUtils-Wrapper",
+        "Swizzler",
+        .product(name: "SwiftyBeaver", package: "SwiftyBeaver"),
+        .product(name: "Moya", package: "Moya"),
+      ],
+      path: "Sources/DebugKitObjC",
+      resources: [.copy("token.txt")],
+      publicHeadersPath: "Headers",
+      cSettings: [
+        .headerSearchPath("PrivateHeaders"),
+      ]
     ),
     .target(
       name: "CoreUtils-Wrapper",
       path: "Sources/Core"
-    )
+    ),
   ]
 )

--- a/examples/LocalPackages/core-utils/Sources/DebugKitObjc/DebugKit.m
+++ b/examples/LocalPackages/core-utils/Sources/DebugKitObjc/DebugKit.m
@@ -1,5 +1,7 @@
 #import <Foundation/Foundation.h>
-#import "DebugKit.h"
+#import <DebugKit.h>
+#import <Diagnose.h>
+#import <Swizzler.h>
 
 @implementation DebugKit
 + (NSBundle *)bundle {
@@ -10,5 +12,9 @@
   NSString *tokenPath = [bundle pathForResource:@"token" ofType:@"txt"];
   NSString *content = [NSString stringWithContentsOfFile:tokenPath encoding:NSUTF8StringEncoding error:nil];
   return [content stringByReplacingOccurrencesOfString:@"\n" withString:@""];
+}
++ (void)diagnose {
+  [Swizzler swizzle:@"foo" with:@"bar" forClass:DebugKit.class];
+  [Diagnoser diagnoseDevice];
 }
 @end

--- a/examples/LocalPackages/core-utils/Sources/DebugKitObjc/Diagnose.m
+++ b/examples/LocalPackages/core-utils/Sources/DebugKitObjc/Diagnose.m
@@ -1,0 +1,9 @@
+#import <Diagnose.h>
+
+@implementation Diagnoser
+
++ (void)diagnoseDevice {
+  NSLog(@"Diagnosing device...");
+}
+
+@end

--- a/examples/LocalPackages/core-utils/Sources/DebugKitObjc/Headers/DebugKit.h
+++ b/examples/LocalPackages/core-utils/Sources/DebugKitObjc/Headers/DebugKit.h
@@ -1,9 +1,13 @@
 #import <Foundation/Foundation.h>
+// 👇 expect xccache to convert to nested angle-bracket style `#import <Swizzler/Swizzler.h>`
+#import <Swizzler.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface DebugKit: NSObject
 @property (class, nonatomic, readonly, strong) NSBundle *bundle;
 + (NSString *)loadToken;
++ (void)diagnose;
 @end
+
 NS_ASSUME_NONNULL_END

--- a/examples/LocalPackages/core-utils/Sources/DebugKitObjc/PrivateHeaders/Diagnose.h
+++ b/examples/LocalPackages/core-utils/Sources/DebugKitObjc/PrivateHeaders/Diagnose.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Diagnoser: NSObject
++ (void)diagnoseDevice;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/examples/LocalPackages/core-utils/Sources/Swizzler/Swizzler.m
+++ b/examples/LocalPackages/core-utils/Sources/Swizzler/Swizzler.m
@@ -1,0 +1,7 @@
+#import "Swizzler.h"
+
+@implementation Swizzler
++ (void)swizzle:(NSString* )m1 with:(NSString *)m2 forClass:(Class)cls {
+  NSLog(@"Swizzle %@ with %@", m1, m2);
+}
+@end

--- a/examples/LocalPackages/core-utils/Sources/Swizzler/Swizzler.swift
+++ b/examples/LocalPackages/core-utils/Sources/Swizzler/Swizzler.swift
@@ -1,3 +1,0 @@
-public struct Swizzler {
-  public static func swizzle(_ m1: String, _ m2: String) { }
-}

--- a/examples/LocalPackages/core-utils/Sources/Swizzler/include/Swizzler.h
+++ b/examples/LocalPackages/core-utils/Sources/Swizzler/include/Swizzler.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Swizzler: NSObject
++ (void)swizzle:(NSString* )m1 with:(NSString *)m2 forClass:(Class)cls;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,5 +1,8 @@
 XCCACHE_ARGS := --verbose
 
+format:
+	cd .. && make format
+
 cache.use:
 	bundle exec xccache use $(XCCACHE_ARGS)
 

--- a/examples/xccache.lock
+++ b/examples/xccache.lock
@@ -54,6 +54,13 @@
           "kind": "upToNextMajorVersion",
           "minimumVersion": "5.7.1"
         }
+      },
+      {
+        "repositoryURL": "https://github.com/facebook/facebook-ios-sdk",
+        "requirement": {
+          "kind": "upToNextMajorVersion",
+          "minimumVersion": "9.0.0"
+        }
       }
     ],
     "dependencies": {
@@ -64,6 +71,7 @@
         "core-utils/ResourceKit",
         "core-utils/Swizzler",
         "ios-maps-sdk/GoogleMaps",
+        "facebook-ios-sdk/FacebookLogin",
         "firebase-ios-sdk/FirebaseCrashlytics",
         "SDWebImage/SDWebImage",
         "SnapKit/SnapKit-Dynamic",

--- a/lib/xccache/spm/desc/desc.rb
+++ b/lib/xccache/spm/desc/desc.rb
@@ -7,6 +7,12 @@ module XCCache
         include Cacheable
         cacheable :resolve_recursive_dependencies
 
+        def self.descs_in_metadata_dir
+          descs = config.instance.spm_metadata_dir.glob("*.json").map { |p| Description.new(p) }
+          descs.each { |d| d.retrieve_pkg_desc = proc { |name| descs[name] } }
+          descs
+        end
+
         def self.in_dir(dir, save_to_dir: nil)
           path = save_to_dir / "#{dir.basename}.json" unless save_to_dir.nil?
           begin

--- a/lib/xccache/spm/desc/target.rb
+++ b/lib/xccache/spm/desc/target.rb
@@ -15,7 +15,11 @@ module XCCache
           @type ||= raw["type"].to_sym
         end
 
-        def bundle_name
+        def module_name
+          name.c99extidentifier
+        end
+
+        def resource_bundle_name
           "#{pkg_name}_#{name}.bundle"
         end
 


### PR DESCRIPTION
In FBSDKLoginKit v9, there's an import using flat angle-bracket style `#import <FBSDKCoreKit.h>`. See: [here](https://github.com/facebook/facebook-ios-sdk/blob/v9.3.0/FBSDKLoginKit/FBSDKLoginKit/include/FBSDKCoreKitImport.h#L24).
While this works if using code, thanks to the visibility in header search paths, it no longer works in prebuilt frameworks because this header belongs to another module (`LegacyCoreKit`).

In this case, we need to resolve the module and convert `#import <foo.h>` to `#import <foo/foo.h>`