### PR TITLE
FEAT: Check sdk triples in cache validation

### DIFF
--- a/lib/xccache/command.rb
+++ b/lib/xccache/command.rb
@@ -1,5 +1,6 @@
 require "claide"
 require "xccache/core/config"
+require "xccache/swift/sdk"
 
 module XCCache
   class Command < CLAide::Command
@@ -14,7 +15,15 @@ module XCCache
       super
       config.verbose = verbose unless verbose.nil?
       @skip_resolving_dependencies = argv.flag?("skip-resolving-dependencies")
-      @install_options = { :skip_resolving_dependencies => @skip_resolving_dependencies }
+      @sdks = str_to_sdks(argv.option("sdk"))
+      @install_options = {
+        :sdks => @sdks,
+        :skip_resolving_dependencies => @skip_resolving_dependencies,
+      }
+    end
+
+    def str_to_sdks(str)
+      (str || "iphonesimulator").split(",").map { |s| Swift::Sdk.new(s) }
     end
   end
 end

--- a/lib/xccache/command/base.rb
+++ b/lib/xccache/command/base.rb
@@ -1,0 +1,16 @@
+require "xccache/installer"
+
+module XCCache
+  class Command
+    class Options
+      SDK = ["--sdk=foo,bar", "SDKs (iphonesimulator, iphoneos, etc.)"].freeze
+      SKIP_RESOLVING_DEPENDENCIES = [
+        "--skip-resolving-dependencies", "Skip resolving package dependencies",
+      ].freeze
+
+      def self.installer_options
+        [SDK, SKIP_RESOLVING_DEPENDENCIES]
+      end
+    end
+  end
+end

--- a/lib/xccache/command/build.rb
+++ b/lib/xccache/command/build.rb
@@ -1,4 +1,5 @@
 require "xccache/installer"
+require_relative "base"
 
 module XCCache
   class Command
@@ -6,10 +7,9 @@ module XCCache
       self.summary = "Build packages to xcframeworks"
       def self.options
         [
-          ["--sdk=iphonesimulator", "SDKs to build (comma separated)"],
+          *Options.installer_options,
           ["--integrate/no-integrate", "Whether to integrate after building target (default: true)"],
           ["--recursive", "Whether to build their recursive targets if cache-missed (default: false)"],
-          ["--skip-resolving-dependencies", "Skip resolving package dependencies"],
         ].concat(super)
       end
       self.arguments = [
@@ -19,13 +19,12 @@ module XCCache
       def initialize(argv)
         super
         @targets = argv.arguments!
-        @sdk = argv.option("sdk")
         @should_integrate = argv.flag?("integrate", true)
         @recursive = argv.flag?("recursive", false)
       end
 
       def run
-        installer = Installer::Build.new(targets: @targets, sdk: @sdk, recursive: @recursive, **@install_options)
+        installer = Installer::Build.new(targets: @targets, recursive: @recursive, **@install_options)
         installer.install!
         # Reuse umbrella_pkg from previous installers
         Installer::Use.new(umbrella_pkg: installer.umbrella_pkg, **@install_options).install! if @should_integrate

--- a/lib/xccache/command/pkg.rb
+++ b/lib/xccache/command/pkg.rb
@@ -1,3 +1,4 @@
+require_relative "base"
 require "xccache/command/pkg/build"
 
 module XCCache

--- a/lib/xccache/command/pkg/build.rb
+++ b/lib/xccache/command/pkg/build.rb
@@ -7,7 +7,7 @@ module XCCache
         self.summary = "Build a Swift package into an xcframework"
         def self.options
           [
-            ["--sdk=foo,bar", "Sdk (iphonesimulator, iphoneos, etc.)"],
+            Options::SDK,
             ["--config=foo", "Configuration (debug, release)"],
             ["--out=foo", "Output directory for the xcframework"],
             ["--checksum/no-checksum", "Whether to include checksum to the binary name"],
@@ -20,7 +20,6 @@ module XCCache
         def initialize(argv)
           super
           @targets = argv.arguments!
-          @sdk = argv.option("sdk")
           @config = argv.option("config")
           @out_dir = argv.option("out")
           @include_checksum = argv.flag?("checksum")
@@ -30,7 +29,7 @@ module XCCache
           pkg = SPM::Package.new
           pkg.build(
             targets: @targets,
-            sdk: @sdk,
+            sdks: @sdks,
             config: @config,
             out_dir: @out_dir,
             checksum: @include_checksum,

--- a/lib/xccache/command/rollback.rb
+++ b/lib/xccache/command/rollback.rb
@@ -1,4 +1,5 @@
 require "xccache/installer"
+require_relative "base"
 
 module XCCache
   class Command

--- a/lib/xccache/command/use.rb
+++ b/lib/xccache/command/use.rb
@@ -1,4 +1,5 @@
 require "xccache/installer"
+require_relative "base"
 
 module XCCache
   class Command
@@ -6,7 +7,7 @@ module XCCache
       self.summary = "Use prebuilt cache for packages"
       def self.options
         [
-          ["--skip-resolving-dependencies", "Skip resolving package dependencies"],
+          *Options.installer_options,
         ].concat(super)
       end
 

--- a/lib/xccache/core/syntax/plist.rb
+++ b/lib/xccache/core/syntax/plist.rb
@@ -1,0 +1,17 @@
+require "cfpropertylist"
+require_relative "hash"
+
+module XCCache
+  class PlistRepresentable < HashRepresentable
+    def load
+      plist = CFPropertyList::List.new(file: path)
+      CFPropertyList.native_types(plist.value)
+    rescue StandardError
+      {}
+    end
+
+    def save(to: nil)
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/xccache/framework/xcframework.rb
+++ b/lib/xccache/framework/xcframework.rb
@@ -11,6 +11,7 @@ module XCCache
         @config = options[:config]
         @sdks = options[:sdks]
         @path = options[:path]
+        raise GeneralError, "Missing sdks for xcframework: #{name}" if @sdks.empty?
       end
 
       def create
@@ -33,8 +34,7 @@ module XCCache
       end
 
       def slices
-        @slices ||= sdks.map do |s|
-          sdk = Swift::Sdk.new(s)
+        @slices ||= sdks.map do |sdk|
           Framework::Slice.new(
             name: name,
             pkg_dir: pkg_dir,

--- a/lib/xccache/framework/xcframework_metadata.rb
+++ b/lib/xccache/framework/xcframework_metadata.rb
@@ -1,0 +1,41 @@
+require "xccache/core/syntax/plist"
+
+module XCCache
+  class Framework
+    class XCFramework
+      class Metadata < PlistRepresentable
+        class Library < Hash
+          def id
+            self["LibraryIdentifier"]
+          end
+
+          def platform
+            self["SupportedPlatform"]
+          end
+
+          def archs
+            self["SupportedArchitectures"]
+          end
+
+          def simulator?
+            self["SupportedPlatformVariant"] == "simulator"
+          end
+
+          def triples
+            @triples ||= archs.map do |arch|
+              simulator? ? "#{arch}-#{platform}-simulator" : "#{arch}-#{platform}"
+            end
+          end
+        end
+
+        def available_libraries
+          @available_libraries ||= raw.fetch("AvailableLibraries", []).map { |h| Library.new.merge(h) }
+        end
+
+        def triples
+          @triples ||= available_libraries.flat_map(&:triples)
+        end
+      end
+    end
+  end
+end

--- a/lib/xccache/installer.rb
+++ b/lib/xccache/installer.rb
@@ -8,13 +8,20 @@ module XCCache
     def initialize(options = {})
       @umbrella_pkg = options[:umbrella_pkg]
       @skip_resolving_dependencies = options[:skip_resolving_dependencies]
+      @sdks = options[:sdks]
     end
 
     def perform_install
       config.in_installation = true
       verify_projects!
-      sync_lockfile if @umbrella_pkg.nil?
-      umbrella_pkg.prepare(skip_resolve: @skip_resolving_dependencies) if @umbrella_pkg.nil?
+      if @umbrella_pkg.nil?
+        sync_lockfile
+        umbrella_pkg.prepare(
+          skip_resolve: @skip_resolving_dependencies,
+          sdks: @sdks,
+        )
+      end
+
       yield
       umbrella_pkg.write_manifest
       umbrella_pkg.gen_cachemap_viz

--- a/lib/xccache/installer/build.rb
+++ b/lib/xccache/installer/build.rb
@@ -6,7 +6,6 @@ module XCCache
       def initialize(options = {})
         super
         @targets = options[:targets]
-        @sdk = options[:sdk]
         @recursive = options[:recursive]
       end
 
@@ -14,7 +13,7 @@ module XCCache
         perform_install do
           umbrella_pkg.build(
             targets: @targets,
-            sdk: @sdk,
+            sdks: @sdks,
             out_dir: config.spm_binaries_frameworks_dir,
             checksum: true,
             recursive: @recursive,

--- a/lib/xccache/spm/pkg/base.rb
+++ b/lib/xccache/spm/pkg/base.rb
@@ -1,6 +1,7 @@
 require "json"
 require "xccache/framework/slice"
 require "xccache/framework/xcframework"
+require "xccache/framework/xcframework_metadata"
 require "xccache/swift/sdk"
 
 module XCCache
@@ -31,14 +32,13 @@ module XCCache
         end
       end
 
-      def build_target(target: nil, sdk: nil, config: nil, out_dir: nil, **options)
+      def build_target(target: nil, sdks: nil, config: nil, out_dir: nil, **options)
         target_pkg_desc = pkg_desc_of_target(target, skip_resolve: options[:skip_resolve])
         if target_pkg_desc.binary_targets.any? { |t| t.name == target }
           return UI.warn("Target #{target} is a binary target -> no need to build")
         end
 
         target = target_pkg_desc.get_target(target)
-        sdks = (sdk || "iphonesimulator").split(",")
 
         out_dir = Pathname(out_dir || ".")
         out_dir /= target.name if options[:checksum]

--- a/lib/xccache/spm/pkg/umbrella.rb
+++ b/lib/xccache/spm/pkg/umbrella.rb
@@ -30,7 +30,7 @@ module XCCache
           gen_metadata
           resolve_recursive_dependencies
           create_symlinks_to_artifacts
-          sync_cachemap
+          sync_cachemap(sdks: options[:sdks])
         end
 
         def resolve_recursive_dependencies

--- a/lib/xccache/spm/pkg/umbrella/build.rb
+++ b/lib/xccache/spm/pkg/umbrella/build.rb
@@ -8,7 +8,7 @@ module XCCache
 
           UI.info("-> Targets to build: #{to_build.to_s.bold}")
           super(options.merge(:targets => to_build))
-          sync_cachemap
+          sync_cachemap(sdks: options[:sdks])
         end
 
         def targets_to_build(options)

--- a/lib/xccache/swift/sdk.rb
+++ b/lib/xccache/swift/sdk.rb
@@ -18,8 +18,10 @@ module XCCache
         name
       end
 
-      def triple
-        NAME_TO_TRIPLE[name.to_sym]
+      def triple(without_vendor: false)
+        res = NAME_TO_TRIPLE[name.to_sym]
+        res = res.sub("-apple", "") if without_vendor
+        res
       end
 
       def sdk_path


### PR DESCRIPTION
Check sdk triples (ex. iphonesimulator, iphoneos) in cache validation.

When `--sdk` argument is specified, an xcframework must contain all slices (triples) of the given sdks. Otherwise, it's considered a cache-miss.