### PR TITLE
FIX: Prevent NoMethodError from nil pkg in dependencies

### DIFF
--- a/lib/xccache/installer.rb
+++ b/lib/xccache/installer.rb
@@ -60,7 +60,7 @@ module XCCache
 
     def lockfile_hash_for_project(project)
       deps_by_targets = project.targets.to_h do |target|
-        deps = target.non_xccache_pkg_product_dependencies.map { |d| "#{d.pkg.slug}/#{d.product_name}" }
+        deps = target.non_xccache_pkg_product_dependencies.select(&:pkg).map { |d| "#{d.pkg.slug}/#{d.product_name}" }
         [target.name, deps]
       end
       {

--- a/lib/xccache/xcodeproj/target.rb
+++ b/lib/xccache/xcodeproj/target.rb
@@ -7,11 +7,11 @@ module Xcodeproj
         alias pkg_product_dependencies package_product_dependencies
 
         def non_xccache_pkg_product_dependencies
-          pkg_product_dependencies.reject { |d| d.pkg.xccache_pkg? }
+          pkg_product_dependencies.reject { |d| d.pkg&.xccache_pkg? }
         end
 
         def has_xccache_product_dependency?
-          pkg_product_dependencies.any? { |d| d.pkg.xccache_pkg? }
+          pkg_product_dependencies.any? { |d| d.pkg&.xccache_pkg? }
         end
 
         def has_pkg_product_dependency?(name)


### PR DESCRIPTION
## 🐛 Problem

Some Swift package dependencies do not resolve a valid `pkg`, leading to runtime errors like:

- `undefined method 'xccache_pkg?' for nil`
- `undefined method 'slug' for nil`

These errors occur when `d.pkg` is `nil` and methods are called on it without checking.

---

## ✅ Solution

Added safe checks to prevent calling methods on `nil`:

- Replaced direct calls with the safe navigation operator: `d.pkg&.xccache_pkg?`
- Filtered out nil packages before mapping:  
  `target.non_xccache_pkg_product_dependencies.select (&:pkg)`

---

## 💡 Why

Some entries of `XCSwiftPackageProductDependency` can be unresolved or misconfigured, resulting in a `nil` `pkg`.  
These changes ensure the tool doesn’t crash due to method calls on `nil`.

---

✅ This improves resilience and ensures smoother builds, even when certain dependencies are incomplete or missing.
