### PR TITLE
FIX: Cannot import Testing/XCTest

### DIFF
--- a/examples/EX.xcodeproj/project.pbxproj
+++ b/examples/EX.xcodeproj/project.pbxproj
@@ -36,9 +36,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		1CBE8AAACA849C519746C865 /* xccache.yml */ = {isa = PBXFileReference; includeInIndex = 1; path = xccache.yml; sourceTree = "<group>"; };
+		1CBE8AAACA849C519746C865 /* xccache.yml */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.yaml; path = xccache.yml; sourceTree = "<group>"; };
 		3B5B411E32E4429CC9EDBC87 /* Package.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Package.swift; path = xccache/packages/umbrella/Package.swift; sourceTree = "<group>"; };
-		D1B6F890297CAD42EA43AFB3 /* xccache.lock */ = {isa = PBXFileReference; includeInIndex = 1; path = xccache.lock; sourceTree = "<group>"; };
+		D1B6F890297CAD42EA43AFB3 /* xccache.lock */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = xccache.lock; sourceTree = "<group>"; };
 		F577C62F2D96971200C83C96 /* EX.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EX.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F577C6A82D96A3BD00C83C96 /* config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = config.xcconfig; sourceTree = "<group>"; };
 		F5AF0F9C2DAE09EF00AB812D /* EXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };

--- a/examples/EXTests/SPMPlayground.swift
+++ b/examples/EXTests/SPMPlayground.swift
@@ -1,0 +1,10 @@
+import DebugKit
+import ResourceKit
+import TestKit
+
+func playground() {
+  print(DebugKit.self)      // DebugKit
+  print(ResourceKit.self)   // ResourceKit
+  print(TestKit.self)       // TestKit
+  print(BaseTestCase.self)  // TestKit
+}

--- a/examples/LocalPackages/core-utils/Package.swift
+++ b/examples/LocalPackages/core-utils/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
     .library(name: "Swizzler", targets: ["Swizzler"]),
     .library(name: "ResourceKit", targets: ["ResourceKit"]),
     .library(name: "DebugKit", targets: ["DebugKit"]),
+    .library(name: "TestKit", targets: ["TestKit"]),
   ],
   dependencies: [
     .package(url: "https://github.com/SwiftyBeaver/SwiftyBeaver.git", .upToNextMajor(from: "2.1.1")),
@@ -45,5 +46,6 @@ let package = Package(
       name: "CoreUtils-Wrapper",
       path: "Sources/Core"
     ),
+    .target(name: "TestKit"),
   ]
 )

--- a/examples/LocalPackages/core-utils/Sources/TestKit/TestKit.swift
+++ b/examples/LocalPackages/core-utils/Sources/TestKit/TestKit.swift
@@ -1,0 +1,7 @@
+import Testing
+import XCTest
+
+@objc public class TestKit: NSObject { }
+
+public class BaseTestCase: XCTestCase { }
+public protocol BaseTrait: Trait { }

--- a/examples/xccache.lock
+++ b/examples/xccache.lock
@@ -77,7 +77,9 @@
         "SnapKit/SnapKit-Dynamic",
         "KingfisherWebP/KingfisherWebP"
       ],
-      "EXTests": []
+      "EXTests": [
+        "core-utils/TestKit"
+      ]
     }
   }
 }

--- a/lib/xccache/framework/slice.rb
+++ b/lib/xccache/framework/slice.rb
@@ -28,6 +28,7 @@ module XCCache
           cmd << "-Xswiftc" << "-alias-module-names-in-module-interface"
           cmd << "-Xswiftc" << "-emit-module-interface"
           cmd << "-Xswiftc" << "-no-verify-emitted-module-interface"
+          sdk.swiftc_args.each { |arg| cmd << "-Xswiftc" << arg }
           Sh.run(cmd, suppress_err: /(dependency '.*' is not used by any target|unable to create symbolic link)/)
           create_framework
         end

--- a/lib/xccache/swift/sdk.rb
+++ b/lib/xccache/swift/sdk.rb
@@ -25,7 +25,23 @@ module XCCache
       end
 
       def sdk_path
+        # rubocop:disable Layout/LineLength
+        # /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk
+        # rubocop:enable Layout/LineLength
         @sdk_path ||= Pathname(Sh.capture_output("xcrun --sdk #{name} --show-sdk-path")).realpath
+      end
+
+      def sdk_platform_developer_path
+        @sdk_platform_developer_path ||= sdk_path.parent.parent # iPhoneSimulator.platform/Developer
+      end
+
+      def swiftc_args
+        developer_library_frameworks_path = sdk_platform_developer_path / "Library" / "Frameworks"
+        developer_usr_lib_path = sdk_platform_developer_path / "usr" / "lib"
+        [
+          "-F#{developer_library_frameworks_path}",
+          "-I#{developer_usr_lib_path}",
+        ]
       end
     end
   end


### PR DESCRIPTION
Fixes #59
Root cause: some system frameworks/libraries were not visible to the search paths.