### PR TITLE
FEAT: Add local pkgs to xccache.config group in project structure

### DIFF
--- a/examples/EX.xcodeproj/project.pbxproj
+++ b/examples/EX.xcodeproj/project.pbxproj
@@ -46,6 +46,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		6A1E86E654DF34A6D9F8EA12 /* xccache/packages/local */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			name = "local-packages";
+			path = xccache/packages/local;
+			sourceTree = "<group>";
+		};
 		F577C6312D96971200C83C96 /* EX */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -95,6 +103,7 @@
 				3B5B411E32E4429CC9EDBC87 /* Package.swift */,
 				D1B6F890297CAD42EA43AFB3 /* xccache.lock */,
 				1CBE8AAACA849C519746C865 /* xccache.yml */,
+				6A1E86E654DF34A6D9F8EA12 /* xccache/packages/local */,
 			);
 			name = xccache.config;
 			sourceTree = "<group>";

--- a/lib/xccache/core/config.rb
+++ b/lib/xccache/core/config.rb
@@ -28,6 +28,10 @@ module XCCache
       @spm_sandbox ||= Dir.prepare(sandbox / "packages").expand_path
     end
 
+    def spm_local_pkgs_dir
+      @spm_local_pkgs_dir ||= Dir.prepare(spm_sandbox / "local")
+    end
+
     def spm_binaries_frameworks_dir
       @spm_binaries_frameworks_dir ||= Dir.prepare(spm_umbrella_sandbox / "binaries")
     end

--- a/lib/xccache/installer.rb
+++ b/lib/xccache/installer.rb
@@ -75,11 +75,17 @@ module XCCache
 
     def add_xccache_refs_to_projects
       projects.each do |project|
-        group = project["xccache.config"] || project.new_group("xccache.config")
+        group = project.xccache_config_group
         add_file = proc { |p| group[p.basename.to_s] || group.new_file(p) }
         add_file.call(config.spm_umbrella_sandbox / "Package.swift")
         add_file.call(config.lockfile.path)
         add_file.call(config.path) if config.path.exist?
+        next if group.synced_groups.any? { |g| g.name == "local-packages" }
+
+        group.new_synced_group(
+          name: "local-packages",
+          path: config.spm_local_pkgs_dir.relative_path_from(project.path.parent),
+        )
       end
     end
   end

--- a/lib/xccache/installer/rollback.rb
+++ b/lib/xccache/installer/rollback.rb
@@ -30,7 +30,7 @@ module XCCache
 
         # Remove .binary product from the project
         project.targets.each(&:remove_xccache_product_dependencies)
-        project.xccache_pkg.remove_from_project
+        project.xccache_pkg&.remove_from_project
       end
     end
   end

--- a/lib/xccache/spm/pkg/base.rb
+++ b/lib/xccache/spm/pkg/base.rb
@@ -60,7 +60,6 @@ module XCCache
         UI.section("Resolving package dependencies (package: #{root_dir.basename})", timing: true) do
           Sh.run("swift package resolve --package-path #{root_dir} 2>&1")
         end
-        create_symlinks_to_local_pkgs
         @resolved = true
       end
 
@@ -96,12 +95,6 @@ module XCCache
 
       def pkg_desc
         @pkg_desc ||= Description.in_dir(root_dir)
-      end
-
-      def create_symlinks_to_local_pkgs
-        pkg_desc.dependencies.select(&:local?).each do |dep|
-          dep.path.symlink_to(root_dir / ".build/checkouts/#{dep.slug}")
-        end
       end
     end
   end

--- a/lib/xccache/xcodeproj/file_system_synchronized_root_group.rb
+++ b/lib/xccache/xcodeproj/file_system_synchronized_root_group.rb
@@ -1,0 +1,11 @@
+require "xcodeproj"
+
+module Xcodeproj
+  class Project
+    module Object
+      class PBXFileSystemSynchronizedRootGroup
+        attribute :name, String
+      end
+    end
+  end
+end

--- a/lib/xccache/xcodeproj/group.rb
+++ b/lib/xccache/xcodeproj/group.rb
@@ -1,0 +1,21 @@
+require "xcodeproj"
+
+module Xcodeproj
+  class Project
+    module Object
+      class PBXGroup
+        def synced_groups
+          children.grep(PBXFileSystemSynchronizedRootGroup)
+        end
+
+        def new_synced_group(options = {})
+          synced_group = project.new(PBXFileSystemSynchronizedRootGroup)
+          synced_group.path = options[:path].to_s
+          synced_group.name = options[:name] || options[:path].basename.to_s
+          self << synced_group
+          synced_group
+        end
+      end
+    end
+  end
+end

--- a/lib/xccache/xcodeproj/project.rb
+++ b/lib/xccache/xcodeproj/project.rb
@@ -66,6 +66,10 @@ module Xcodeproj
       pkgs.find { |p| p.slug == name }
     end
 
+    def xccache_config_group
+      self["xccache.config"] || new_group("xccache.config")
+    end
+
     private
 
     def pkg_key_in_hash(hash)


### PR DESCRIPTION
### Changes
Add a group called **local-packages** under the **xccache.config** group of the project structure.
This allows developers to access local packages at hand.
<img width="347" alt="Screenshot 2025-05-07 at 21 03 59" src="https://github.com/user-attachments/assets/69f6512b-68ba-4580-b816-3899eb465426" />

### Why do we need this?
By default, we remove packages from xcodeproj to reduce the overhead package resolution time. If all targets of a certain package is all cached, _the package won't appear in the Package Dependencies section_.

When this behavior happens to a local package, it does not show up in Xcode. But we still need access to source code of local packages (for development).
With this change, developers can always access local packages regardless of their cache-hit states.
