### PR TITLE
REFACTOR: Avoid passing many options around

### DIFF
--- a/lib/xccache/command.rb
+++ b/lib/xccache/command.rb
@@ -11,14 +11,20 @@ module XCCache
     self.default_subcommand = "use"
     self.summary = "xccache - a build caching tool"
 
+    attr_reader :install_options, :build_options
+
     def initialize(argv)
       super
       config.verbose = verbose unless verbose.nil?
-      @skip_resolving_dependencies = argv.flag?("skip-resolving-dependencies")
-      @sdks = str_to_sdks(argv.option("sdk"))
       @install_options = {
-        :sdks => @sdks,
-        :skip_resolving_dependencies => @skip_resolving_dependencies,
+        :sdks => str_to_sdks(argv.option("sdk")),
+        :skip_resolving_dependencies => argv.flag?("skip-resolving-dependencies"),
+      }
+      @build_options = {
+        **@install_options,
+        :config => argv.option("config"),
+        :recursive => argv.flag?("recursive"),
+        :merge_slices => argv.flag?("merge-slices", true),
       }
     end
 

--- a/lib/xccache/command/base.rb
+++ b/lib/xccache/command/base.rb
@@ -13,8 +13,12 @@ module XCCache
         "Whether to merge with existing slices/sdks in the xcframework (default: true)",
       ].freeze
 
-      def self.installer_options
+      def self.install_options
         [SDK, SKIP_RESOLVING_DEPENDENCIES]
+      end
+
+      def self.build_options
+        install_options + [CONFIG, MERGE_SLICES]
       end
     end
   end

--- a/lib/xccache/command/build.rb
+++ b/lib/xccache/command/build.rb
@@ -7,8 +7,7 @@ module XCCache
       self.summary = "Build packages to xcframeworks"
       def self.options
         [
-          *Options.installer_options,
-          Options::MERGE_SLICES,
+          *Options.build_options,
           ["--integrate/no-integrate", "Whether to integrate after building target (default: true)"],
           ["--recursive", "Whether to build their recursive targets if cache-missed (default: false)"],
         ].concat(super)
@@ -21,24 +20,20 @@ module XCCache
         super
         @targets = argv.arguments!
         @should_integrate = argv.flag?("integrate", true)
-        @recursive = argv.flag?("recursive")
-        @merge_slices = argv.flag?("merge-slices", true)
       end
 
       def run
         installer = Installer::Build.new(
+          ctx: self,
           targets: @targets,
-          recursive: @recursive,
-          merge_slices: @merge_slices,
-          **@install_options,
         )
         installer.install!
 
         # Reuse umbrella_pkg from previous installers
         return unless @should_integrate
         Installer::Use.new(
+          ctx: self,
           umbrella_pkg: installer.umbrella_pkg,
-          **@install_options,
         ).install!
       end
     end

--- a/lib/xccache/command/pkg/build.rb
+++ b/lib/xccache/command/pkg/build.rb
@@ -7,11 +7,9 @@ module XCCache
         self.summary = "Build a Swift package into an xcframework"
         def self.options
           [
-            Options::SDK,
-            Options::CONFIG,
+            *Options.build_options,
             ["--out=foo", "Output directory for the xcframework"],
             ["--checksum/no-checksum", "Whether to include checksum to the binary name"],
-            Options::MERGE_SLICES,
           ].concat(super)
         end
         self.arguments = [
@@ -21,22 +19,18 @@ module XCCache
         def initialize(argv)
           super
           @targets = argv.arguments!
-          @config = argv.option("config")
           @out_dir = argv.option("out")
           @include_checksum = argv.flag?("checksum")
-          @merge_slices = argv.flag?("merge-slices", true)
         end
 
         def run
           pkg = SPM::Package.new
           pkg.build(
             targets: @targets,
-            sdks: @sdks,
             config: @config,
             out_dir: @out_dir,
             checksum: @include_checksum,
-            merge_slices: @merge_slices,
-            skip_resolve: @skip_resolving_dependencies,
+            **@build_options,
           )
         end
       end

--- a/lib/xccache/command/rollback.rb
+++ b/lib/xccache/command/rollback.rb
@@ -7,7 +7,7 @@ module XCCache
       self.summary = "Roll back prebuilt cache for packages"
 
       def run
-        Installer::Rollback.new.install!
+        Installer::Rollback.new(ctx: self).install!
       end
     end
   end

--- a/lib/xccache/command/use.rb
+++ b/lib/xccache/command/use.rb
@@ -7,12 +7,12 @@ module XCCache
       self.summary = "Use prebuilt cache for packages"
       def self.options
         [
-          *Options.installer_options,
+          *Options.install_options,
         ].concat(super)
       end
 
       def run
-        Installer::Use.new(**@install_options).install!
+        Installer::Use.new(ctx: self).install!
       end
     end
   end

--- a/lib/xccache/installer.rb
+++ b/lib/xccache/installer.rb
@@ -6,9 +6,11 @@ module XCCache
     include PkgMixin
 
     def initialize(options = {})
+      ctx = options[:ctx]
+      raise GeneralError, "Missing context (Command) for #{self.class}" if ctx.nil?
       @umbrella_pkg = options[:umbrella_pkg]
-      @skip_resolving_dependencies = options[:skip_resolving_dependencies]
-      @sdks = options[:sdks]
+      @install_options = ctx.install_options
+      @build_options = ctx.build_options
     end
 
     def perform_install
@@ -16,10 +18,7 @@ module XCCache
       verify_projects!
       if @umbrella_pkg.nil?
         sync_lockfile
-        umbrella_pkg.prepare(
-          skip_resolve: @skip_resolving_dependencies,
-          sdks: @sdks,
-        )
+        umbrella_pkg.prepare(**@install_options)
       end
 
       yield

--- a/lib/xccache/installer/build.rb
+++ b/lib/xccache/installer/build.rb
@@ -6,20 +6,15 @@ module XCCache
       def initialize(options = {})
         super
         @targets = options[:targets]
-        @recursive = options[:recursive]
-        @merge_slices = options[:merge_slices]
       end
 
       def install!
         perform_install do
           umbrella_pkg.build(
             targets: @targets,
-            sdks: @sdks,
             out_dir: config.spm_binaries_frameworks_dir,
             checksum: true,
-            merge_slices: @merge_slices,
-            recursive: @recursive,
-            skip_resolve: @skip_resolving_dependencies,
+            **@build_options,
           )
         end
       end

--- a/lib/xccache/spm/pkg/base.rb
+++ b/lib/xccache/spm/pkg/base.rb
@@ -33,7 +33,7 @@ module XCCache
       end
 
       def build_target(target: nil, sdks: nil, config: nil, out_dir: nil, **options)
-        target_pkg_desc = pkg_desc_of_target(target, skip_resolve: options[:skip_resolve])
+        target_pkg_desc = pkg_desc_of_target(target, skip_resolving_dependencies: options[:skip_resolving_dependencies])
         if target_pkg_desc.binary_targets.any? { |t| t.name == target }
           return UI.warn("Target #{target} is a binary target -> no need to build")
         end
@@ -70,7 +70,7 @@ module XCCache
         raise GeneralError, "No Package.swift in #{root_dir}. Are you sure you're running on a package dir?"
       end
 
-      def pkg_desc_of_target(name, skip_resolve: false)
+      def pkg_desc_of_target(name, skip_resolving_dependencies: false)
         # The current package contains the given target
         return pkg_desc if pkg_desc.has_target?(name)
 
@@ -81,7 +81,7 @@ module XCCache
           )
         end
         # Otherwise, it's inside one of the dependencies. Need to resolve then find it
-        resolve unless skip_resolve
+        resolve unless skip_resolving_dependencies
 
         @descs ||= if Config.instance.in_installation?
                    then Description.descs_in_metadata_dir[0]

--- a/lib/xccache/spm/pkg/umbrella.rb
+++ b/lib/xccache/spm/pkg/umbrella.rb
@@ -25,7 +25,7 @@ module XCCache
 
         def prepare(options = {})
           create
-          resolve unless options[:skip_resolve]
+          resolve unless options[:skip_resolving_dependencies]
           create_symlinks_for_convenience
           create_symlinks_to_local_pkgs
           gen_metadata


### PR DESCRIPTION
Avoid passing many options around (merge_slices, skip_resolving_dependencies, ...).
-> Group them into `install_options` and `build_options`