### PR TITLE
FIX: Min deployment target not specified when overriding resource_bundle_accessor

### DIFF
--- a/lib/xccache/spm/build.rb
+++ b/lib/xccache/spm/build.rb
@@ -9,12 +9,14 @@ module XCCache
         @module_name = @name.c99extidentifier
         @pkg_dir = Pathname(options[:pkg_dir] || ".").expand_path
         @pkg_desc = options[:pkg_desc]
+        @ctx_desc = options[:ctx_desc] # Context desc, could be an umbrella or a standalone pkg
         @sdks = options[:sdks] || []
         @sdk = options[:sdk] || @sdks&.first
         @config = options[:config] || "debug"
         @path = options[:path]
         @tmpdir = options[:tmpdir]
         @library_evolution = options[:library_evolution]
+        @sdks.each { |sdk| sdk.version = @ctx_desc.platforms[sdk.platform] } if @ctx_desc
       end
 
       def build(options = {})
@@ -41,7 +43,7 @@ module XCCache
       def swift_build_args
         [
           "--configuration", config,
-          "--triple", sdk.triple,
+          "--triple", sdk.triple(with_version: true),
         ]
       end
 

--- a/lib/xccache/spm/desc/desc.rb
+++ b/lib/xccache/spm/desc/desc.rb
@@ -19,6 +19,10 @@ module XCCache
           raw["_metadata"] ||= {}
         end
 
+        def platforms
+          @platforms ||= raw.fetch("platforms", []).to_h { |h| [h["platformName"].to_sym, h["version"]] }
+        end
+
         def dependencies
           @dependencies ||= fetch("dependencies", Dependency)
         end

--- a/lib/xccache/spm/pkg/base.rb
+++ b/lib/xccache/spm/pkg/base.rb
@@ -62,6 +62,7 @@ module XCCache
             path: binary_path,
             tmpdir: tmpdir,
             pkg_desc: target_pkg_desc,
+            ctx_desc: pkg_desc || target_pkg_desc,
             library_evolution: options[:library_evolution],
           ).build(**options)
         end
@@ -73,6 +74,10 @@ module XCCache
         return if @resolved
         xccache_proxy.run("resolve --pkg #{root_dir} --metadata #{metadata_dir}")
         @resolved = true
+      end
+
+      def pkg_desc
+        descs_by_name[root_dir.basename.to_s]
       end
 
       def pkg_desc_of_target(name, **options)

--- a/lib/xccache/spm/pkg/proxy.rb
+++ b/lib/xccache/spm/pkg/proxy.rb
@@ -30,7 +30,7 @@ module XCCache
         end
 
         def invalidate_cache(sdks: [])
-          UI.message("Invalidating cache (sdks: #{sdks.map(&:name)})")
+          UI.message("Invalidating cache (sdks: #{sdks.map(&:to_s).join(', ')})")
 
           config.spm_cache_dir.glob("*/*.{xcframework,macro}").each do |p|
             cmps = p.basename(".*").to_s.split("-")
@@ -45,7 +45,7 @@ module XCCache
 
             # For regular targets, the xcframework must satisfy the sdk constraints (ie. containing all the slices)
             metadata = XCFramework::Metadata.new(p / "Info.plist")
-            expected_triples = sdks.map { |sdk| sdk.triple(without_vendor: true) }
+            expected_triples = sdks.map { |sdk| sdk.triple(with_vendor: false) }
             missing_triples = expected_triples - metadata.triples
             missing_triples.empty? ? accept_cache.call : reject_cache.call
           end

--- a/lib/xccache/spm/xcframework/slice.rb
+++ b/lib/xccache/spm/xcframework/slice.rb
@@ -33,14 +33,14 @@ module XCCache
         if use_clang?
           cmd = ["xcrun", "clang"]
           cmd << "-x" << "objective-c"
-          cmd << "-target" << sdk.triple << "-isysroot" << sdk.sdk_path
+          cmd << "-target" << sdk.triple(with_version: true) << "-isysroot" << sdk.sdk_path
           cmd << "-o" << obj_path.to_s
           cmd << "-c" << source_path
         else
           cmd = ["xcrun", "swiftc"]
           cmd << "-emit-library" << "-emit-object"
           cmd << "-module-name" << module_name
-          cmd << "-target" << sdk.triple << "-sdk" << sdk.sdk_path
+          cmd << "-target" << sdk.triple(with_version: true) << "-sdk" << sdk.sdk_path
           cmd << "-o" << obj_path.to_s
           cmd << source_path
         end


### PR DESCRIPTION
When building a target having resources for macOS, the step to override resource_bundle_accessor failed, saying
```
Swift requires a minimum deployment target of macOS 10.9.0
```
This PR fixes that issue.