### PR TITLE
FIX: Empty binaries dir

### DIFF
--- a/lib/xccache/core/config.rb
+++ b/lib/xccache/core/config.rb
@@ -40,11 +40,11 @@ module XCCache
     end
 
     def spm_local_pkgs_dir
-      @spm_local_pkgs_dir ||= Dir.prepare(spm_sandbox / "local", clean: true)
+      @spm_local_pkgs_dir ||= Dir.prepare(spm_sandbox / "local")
     end
 
-    def spm_xcconfig_dir
-      @spm_xcconfig_dir ||= Dir.prepare(spm_sandbox / "xcconfigs", clean: true)
+    def spm_xcconfigs_dir
+      @spm_xcconfigs_dir ||= Dir.prepare(spm_sandbox / "xcconfigs")
     end
 
     def spm_cache_dir
@@ -52,7 +52,7 @@ module XCCache
     end
 
     def spm_binaries_dir
-      @spm_binaries_dir ||= Dir.prepare(spm_sandbox / "binaries", clean: true)
+      @spm_binaries_dir ||= Dir.prepare(spm_sandbox / "binaries")
     end
 
     def spm_build_dir

--- a/lib/xccache/installer/integration/supporting_files.rb
+++ b/lib/xccache/installer/integration/supporting_files.rb
@@ -11,7 +11,7 @@ module XCCache
 
       def gen_xcconfigs
         macros_config_by_targets.each do |target, hash|
-          xcconfig_path = config.spm_xcconfig_dir / "#{target}.xcconfig"
+          xcconfig_path = config.spm_xcconfigs_dir / "#{target}.xcconfig"
           UI.message("XCConfig of target #{target} at: #{xcconfig_path}")
           Xcodeproj::Config.new(hash).save_as(xcconfig_path)
         end


### PR DESCRIPTION
The problem was caused by the `clean: true` option in the init of `spm_binaries_dir`
```rb
  def spm_binaries_dir
    @spm_binaries_dir ||= Dir.prepare(spm_sandbox / "binaries", clean: true)
  end
```